### PR TITLE
comma-dangleのルール変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.idea

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -12,7 +12,7 @@ module.exports = {
     'brace-style': 'error',
 
     // require or disallow trailing commas
-    'comma-dangle': ['error', 'only-multiline'],
+    'comma-dangle': ['error', 'always-multiline'],
 
     // enforce consistent spacing before and after commas
     'comma-spacing': ['error', {


### PR DESCRIPTION
以前、comma-dangleのルールを変更しているようですが、カンマを強制されていなかったので変更させて欲しいです。

https://github.com/MatchingAgent/eslint-config-tapplint/pull/3

参照：[require or disallow trailing commas (comma-dangle)](https://eslint.org/docs/rules/comma-dangle)

>Examples of correct code for this rule with the "only-multiline" option:
>/*eslint comma-dangle: ["error", "only-multiline"]*/
>
>var foo = {
>    bar: "baz",
>    qux: "quux",
>};
>
>var foo = {
>    bar: "baz",
>    qux: "quux"
>};
>...